### PR TITLE
variant-dev and rapidjson-dev rdepends on variant respectively 

### DIFF
--- a/recipes-devtools/geojsonvt/geojsonvt_4.1.2.bb
+++ b/recipes-devtools/geojsonvt/geojsonvt_4.1.2.bb
@@ -37,4 +37,4 @@ do_install() {
     oe_runmake -C${S}/build install
 }
 
-PACKAGES = "${PN}-dev ${PN}-staticdev"
+PACKAGES = "${PN} ${PN}-dev ${PN}-staticdev"

--- a/recipes-devtools/geojsonvt/geojsonvt_4.1.2.bb
+++ b/recipes-devtools/geojsonvt/geojsonvt_4.1.2.bb
@@ -35,6 +35,7 @@ do_compile() {
 
 do_install() {
     oe_runmake -C${S}/build install
+    chown -R root:root ${D}${libdir}/libgeojsonvt.a
 }
 
 PACKAGES = "${PN} ${PN}-dev ${PN}-staticdev"

--- a/recipes-devtools/geometryhpp/geometryhpp_0.1.0.bb
+++ b/recipes-devtools/geometryhpp/geometryhpp_0.1.0.bb
@@ -27,4 +27,4 @@ do_install() {
     cp -R ${S}/include/mapbox/* ${D}/${includedir}/mapbox
 }
 
-PACKAGES = "${PN}-dev"
+PACKAGES = "${PN} ${PN}-dev"

--- a/recipes-devtools/nunicode/nunicode_1.6.bb
+++ b/recipes-devtools/nunicode/nunicode_1.6.bb
@@ -33,4 +33,4 @@ FILES_${PN}-dev += "\
     ${libdir}/cmake/nunicode/nunicode-config.cmake \
     ${libdir}/cmake/nunicode/nunicode-config-noconfig.cmake"
 
-PACKAGES = "${PN}-dev ${PN}-staticdev"
+PACKAGES = "${PN} ${PN}-dev ${PN}-staticdev"

--- a/recipes-devtools/rapidjson/rapidjson_1.0.2.bb
+++ b/recipes-devtools/rapidjson/rapidjson_1.0.2.bb
@@ -15,4 +15,4 @@ do_install() {
     cp -r ${S}/include/rapidjson ${D}/${includedir}
 }
 
-PACKAGES = "${PN}-dev"
+PACKAGES = "${PN} ${PN}-dev"

--- a/recipes-devtools/variant/variant_1.1.0.bb
+++ b/recipes-devtools/variant/variant_1.1.0.bb
@@ -19,4 +19,4 @@ do_install() {
     cp ${S}/*.hpp ${D}/${includedir}/mapbox
 }
 
-PACKAGES = "${PN}-dev"
+PACKAGES = "${PN} ${PN}-dev"


### PR DESCRIPTION
Got this message when building yocto  jethro.

```
WARNING: QA Issue: variant-dev rdepends on variant, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: rapidjson-dev rdepends on rapidjson, but it isn't a build dependency? [build-deps]
```